### PR TITLE
Only trigger onStart when the compiler starts

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class WebpackMessages {
 		const name = this.name ? ` ${chalk.cyan(this.name)} bundle` : '';
 		const onStart = _ => this.logger(`Building${name}...`);
 
-		compiler.plugin('compilation', onStart);
+		compiler.plugin('compile', onStart);
 		compiler.plugin('invalid', _ => clear() && onStart());
 
 		compiler.plugin('done', stats => {


### PR DESCRIPTION
`compilation` might be triggered multiple times during a build, which leads to multiple `Building ${name} bundle...`.

`compile` is only triggered once, when the compiler starts.

|before|after|
|-------|----|
|<img width="382" alt="screen shot 2017-08-14 at 1 18 37 pm" src="https://user-images.githubusercontent.com/2530413/29269846-0d06c9ce-80f4-11e7-9423-ea4abe653ec9.png">|<img width="398" alt="screen shot 2017-08-14 at 1 19 08 pm" src="https://user-images.githubusercontent.com/2530413/29269852-12c82402-80f4-11e7-9a8e-4ce2ffc4f66f.png">|

