### PR TITLE
Change hook name for Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class WebpackMessages {
 		};
 
 		if (compiler.hooks !== void 0) {
-			compiler.hooks.compilation.tap(NAME, onStart);
+			compiler.hooks.compile.tap(NAME, onStart);
 			compiler.hooks.invalid.tap(NAME, _ => clear() && onStart());
 			compiler.hooks.done.tap(NAME, onComplete);
 		} else {


### PR DESCRIPTION
Using 'compilation' I was receiving many 'Building X' logs before a single build completed. I tried this on a few projects and 'compile' seems to instead be correct. `compile` is also what is used on Webpack <= 3.x and as far as I can tell nothing changed with that event between 3 and 4 so they should probably be consistent anyways.