### PR TITLE
Add TSDoc types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,24 @@
+export = WebpackMessages;
+/** @typedef {{name?: string; onComplete?: (...args: unknown[]) => void; logger?: (msg: string) => void; }} Options*/
+/** @typedef {import('webpack').WebpackPluginInstance} WebpackPluginInstance */
+/** @implements {WebpackPluginInstance} */
+declare class WebpackMessages implements WebpackPluginInstance {
+    /** @param {Options} [opts] */
+    constructor(opts?: Options);
+    name: string;
+    onDone: (...args: unknown[]) => void;
+    logger: (str: string) => void;
+    /** @type {(str: string, arr?: string[]) => void} */
+    printError(str: string, arr: string[]): void;
+    /** @param {import('webpack').Compiler} compiler */
+    apply(compiler: import('webpack').Compiler): void;
+}
+declare namespace WebpackMessages {
+    export { Options, WebpackPluginInstance };
+}
+type WebpackPluginInstance = import('webpack').WebpackPluginInstance;
+type Options = {
+    name?: string;
+    onComplete?: (...args: unknown[]) => void;
+    logger?: (msg: string) => void;
+};

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const log = str => console.log(str);
 const clear = _ => (cClear(true),true);
 
 /** @typedef {{name?: string; onComplete?: (...args: unknown[]) => void; logger?: (msg: string) => void; }} Options*/
+/** @typedef {import('webpack').WebpackPluginInstance} WebpackPluginInstance */
 
+/** @implements {WebpackPluginInstance} */
 class WebpackMessages {
 
 	/** @param {Options} [opts] */

--- a/index.js
+++ b/index.js
@@ -3,10 +3,16 @@ const cClear = require('console-clear');
 const format = require('webpack-format-messages');
 
 const NAME = 'webpack-messages';
+/** @param {string} str */
 const log = str => console.log(str);
+/** @param {string} [_] */
 const clear = _ => (cClear(true),true);
 
+/** @typedef {{name?: string; onComplete?: (...args: unknown[]) => void; logger?: (msg: string) => void; }} Options*/
+
 class WebpackMessages {
+
+	/** @param {Options} [opts] */
 	constructor(opts) {
 		opts = opts || {};
 		this.name = opts.name;
@@ -14,11 +20,13 @@ class WebpackMessages {
 		this.logger = opts.logger || log;
 	}
 
+	/** @type {(str: string, arr?: string[]) => void} */
 	printError(str, arr) {
 		arr && (str += '\n\n' + arr.join(''));
 		clear() && this.logger(str);
 	}
 
+	/** @param {import('webpack').Compiler} compiler */
 	apply(compiler) {
 		const name = this.name ? ` ${colors.cyan(this.name)} bundle` : '';
 		const onStart = _ => this.logger(`Building${name}...`);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "output",
     "stats"
   ],
+  "scripts": {
+    "types": "npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir ."
+  },
   "dependencies": {
     "console-clear": "^1.0.0",
     "kleur": "^3.0.0",


### PR DESCRIPTION
Add TSDoc style types in the `index.js`, and add a script to generate the declaration file automatically, so these types are available to consumers.

```sh
npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir .
```

Fixes #6 